### PR TITLE
Add puppet configuration for b.bbb-vpn

### DIFF
--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -20,6 +20,12 @@ mod 'files',
   :git => 'https://github.com/freifunk/berlin-puppet-files'
 mod 'vpn03',
   :git => 'https://github.com/freifunk-berlin/puppet-vpn03'
+mod 'tunneldigger',
+  :git => 'https://github.com/freifunk-berlin/puppet-tunneldigger'
+mod 'communitytunnel',
+  :git => 'https://github.com/freifunk-berlin/puppet-communitytunnel'
+mod 'bbbdigger',
+  :git => 'https://github.com/freifunk-berlin/puppet-bbbdigger'
 mod 'uwsgi',
   :git => 'https://github.com/Engage/puppet-uwsgi'
 mod 'python',

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -48,7 +48,7 @@ GIT
 GIT
   remote: https://github.com/freifunk-berlin/puppet-bbbdigger
   ref: master
-  sha: a7ddd7a2ae007ff4d398a7ce7932b5b5fc202fbc
+  sha: e437669019314a3743ca5a1087ef29939d36919e
   specs:
     bbbdigger (0.0.1)
 

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -48,7 +48,7 @@ GIT
 GIT
   remote: https://github.com/freifunk-berlin/puppet-bbbdigger
   ref: master
-  sha: 6570bb703d794adf6cadada5463516f1e5fd02e9
+  sha: dbf6927799d264d110a5efa7f1b1124b2c6b7e1f
   specs:
     bbbdigger (0.0.1)
 

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -48,14 +48,14 @@ GIT
 GIT
   remote: https://github.com/freifunk-berlin/puppet-bbbdigger
   ref: master
-  sha: dbf6927799d264d110a5efa7f1b1124b2c6b7e1f
+  sha: 6570bb703d794adf6cadada5463516f1e5fd02e9
   specs:
     bbbdigger (0.0.1)
 
 GIT
   remote: https://github.com/freifunk-berlin/puppet-communitytunnel
   ref: master
-  sha: 42e3070632a66e756de1605913a86c97884360f0
+  sha: 90eb87be58284c86d66b053a4e7cebca2a24968c
   specs:
     communitytunnel (0.0.1)
 

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -55,14 +55,14 @@ GIT
 GIT
   remote: https://github.com/freifunk-berlin/puppet-communitytunnel
   ref: master
-  sha: 1db51d7318667841d73d411e2a9c92e15587c1da
+  sha: 42e3070632a66e756de1605913a86c97884360f0
   specs:
     communitytunnel (0.0.1)
 
 GIT
   remote: https://github.com/freifunk-berlin/puppet-tunneldigger
   ref: master
-  sha: 05b5fafeae44765253d2be35bdfd5154345e3d6a
+  sha: 7ebc1327b47ce7d34b1351186839f09d3fce08da
   specs:
     tunneldigger (0.0.1)
 

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -46,16 +46,37 @@ GIT
     rrdcached (0.0.1)
 
 GIT
+  remote: https://github.com/freifunk-berlin/puppet-bbbdigger
+  ref: master
+  sha: a7ddd7a2ae007ff4d398a7ce7932b5b5fc202fbc
+  specs:
+    bbbdigger (0.0.1)
+
+GIT
+  remote: https://github.com/freifunk-berlin/puppet-communitytunnel
+  ref: master
+  sha: 1db51d7318667841d73d411e2a9c92e15587c1da
+  specs:
+    communitytunnel (0.0.1)
+
+GIT
+  remote: https://github.com/freifunk-berlin/puppet-tunneldigger
+  ref: master
+  sha: 05b5fafeae44765253d2be35bdfd5154345e3d6a
+  specs:
+    tunneldigger (0.0.1)
+
+GIT
   remote: https://github.com/freifunk-berlin/puppet-vpn03
   ref: master
-  sha: d11d9a64df3fc39d2a305fd5f8be3f2916572ba4
+  sha: 34e4231440bd847cf54c209e475329196d0c151c
   specs:
     vpn03 (0.0.1)
 
 GIT
   remote: https://github.com/freifunk/berlin-puppet-files
   ref: master
-  sha: 758ef56c8b2daae64f8e19862243f53bcad96b91
+  sha: 0eb5f39eacc3fde3efb23b2bafe0fde835bb0742
   specs:
     files (0.0.1)
 
@@ -104,7 +125,9 @@ GIT
     sysctl (1.0.2)
 
 DEPENDENCIES
+  bbbdigger (>= 0)
   collectd (>= 0)
+  communitytunnel (>= 0)
   exim4 (>= 0)
   files (>= 0)
   nginx (>= 0)
@@ -117,6 +140,7 @@ DEPENDENCIES
   python (>= 0)
   rrdcached (>= 0)
   sysctl (>= 0)
+  tunneldigger (>= 0)
   unattended_upgrades (>= 0)
   uwsgi (>= 0)
   vpn03 (>= 0)

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -48,7 +48,7 @@ GIT
 GIT
   remote: https://github.com/freifunk-berlin/puppet-bbbdigger
   ref: master
-  sha: e437669019314a3743ca5a1087ef29939d36919e
+  sha: 6570bb703d794adf6cadada5463516f1e5fd02e9
   specs:
     bbbdigger (0.0.1)
 

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -698,7 +698,7 @@ node 'l105-bbbvpn' {
     address          => '77.87.49.11',
     interface        => 'eth0',
     mesh_address     => '10.230.38.205',
-    mesh_interface   => 'eth1',
+    mesh_interface   => 'backbone',
     tunnel_address   => '10.36.193.1/24',
     dhcp_range       => '10.36.193.4,10.36.193.254,255.255.255.0,1h',
     name             => 'b.bbb-vpn',

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -699,7 +699,7 @@ node 'l105-bbbvpn' {
     interface        => 'eth0',
     mesh_address     => '10.230.38.205',
     mesh_interface   => 'eth1',
-    tunnel_address   => '10.36.193.1',
+    tunnel_address   => '10.36.193.1/24',
     dhcp_range       => '10.36.193.4,10.36.193.254,255.255.255.0,1h',
     name             => 'b.bbb-vpn',
   }

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -691,3 +691,16 @@ node 'vpn03g' {
   class {'collectd::plugin::processes':}
   class {'collectd::plugin::swap':}
 }
+
+node 'l105-bbbvpn' {
+  class { 'base_node': }
+  class { 'bbbdigger':
+    address          => '77.87.49.11',
+    interface        => 'eth0',
+    mesh_address     => '10.230.38.205',
+    mesh_interface   => 'eth1',
+    tunnel_address   => '10.36.193.1',
+    dhcp_range       => '10.36.193.4,10.36.193.254,255.255.255.0,1h',
+    name             => 'b.bbb-vpn',
+  }
+}


### PR DESCRIPTION
The server b.bbb-vpn is a tunneldigger based solution for OLSR islands to connect with the Berlin Backbone.  The local hostname for b.bbb-vpn is l105-bbbvpn.